### PR TITLE
Add a global default no op logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -18,3 +18,13 @@ type noOpLogger struct{}
 func (n *noOpLogger) Log(v ...interface{}) {}
 
 func (n *noOpLogger) Logf(format string, v ...interface{}) {}
+
+// Log logs using the default logger
+func Log(v ...interface{}) {
+	DefaultLogger.Log(v...)
+}
+
+// Logf logs formatted using the default logger
+func Logf(format string, v ...interface{}) {
+	DefaultLogger.Logf(format, v...)
+}

--- a/log.go
+++ b/log.go
@@ -6,3 +6,15 @@ type Logger interface {
 	Log(v ...interface{})
 	Logf(format string, v ...interface{})
 }
+
+var (
+	// The global default logger
+	DefaultLogger = &noOpLogger{}
+)
+
+// noOpLogger is used as a placeholder for the default logger
+type noOpLogger struct{}
+
+func (n *noOpLogger) Log(v ...interface{}) {}
+
+func (n *noOpLogger) Logf(format string, v ...interface{}) {}

--- a/log.go
+++ b/log.go
@@ -9,7 +9,7 @@ type Logger interface {
 
 var (
 	// The global default logger
-	DefaultLogger = &noOpLogger{}
+	DefaultLogger Logger = &noOpLogger{}
 )
 
 // noOpLogger is used as a placeholder for the default logger

--- a/log_test.go
+++ b/log_test.go
@@ -27,3 +27,9 @@ func TestLogger(t *testing.T) {
 	testLog(l)
 	testLogf(l)
 }
+
+func TestNoOpLogger(t *testing.T) {
+	l := new(noOpLogger)
+	testLog(l)
+	testLogf(l)
+}


### PR DESCRIPTION
This a top level global default logger variable with a no op logger so that we don't actually import anything else and don't enforce any opinions by default. This stems from a personal use case in micro where we do not want to define a logging interface, do not want to accept one either but want to make use of something. Seems like something that might be useful.