### PR TITLE
*: Remove log.Logger initialization

### DIFF
--- a/fmt/fmt.go
+++ b/fmt/fmt.go
@@ -2,15 +2,9 @@ package fmt
 
 import (
 	"fmt"
-
-	"github.com/go-log/log"
 )
 
 type fmtLogger struct{}
-
-var (
-	_ log.Logger = New()
-)
 
 func (t *fmtLogger) Log(v ...interface{}) {
 	fmt.Print(v...)

--- a/log/log.go
+++ b/log/log.go
@@ -2,15 +2,9 @@ package log
 
 import (
 	golog "log"
-
-	"github.com/go-log/log"
 )
 
 type logLogger struct{}
-
-var (
-	_ log.Logger = New()
-)
 
 func (t *logLogger) Log(v ...interface{}) {
 	golog.Print(v...)

--- a/logrus/logrus.go
+++ b/logrus/logrus.go
@@ -1,17 +1,12 @@
 package logrus
 
 import (
-	"github.com/go-log/log"
 	"github.com/sirupsen/logrus"
 )
 
 type logrusLogger struct {
 	*logrus.Entry
 }
-
-var (
-	_ log.Logger = New()
-)
 
 func (l *logrusLogger) Log(v ...interface{}) {
 	if l.Entry != nil {
@@ -29,7 +24,7 @@ func (l *logrusLogger) Logf(format string, v ...interface{}) {
 	}
 }
 
-func WithFields(f logrus.Fields) log.Logger {
+func WithFields(f logrus.Fields) *logrusLogger {
 	return &logrusLogger{logrus.WithFields(f)}
 }
 


### PR DESCRIPTION
These seem to all be descended from 7fc4de0e (2017-05-04)  But (as the unit tests show), we don't need this line to satisfy the interface.

You *might* want something like this line to automatically clobber `DefaultLogger` on import.  But `DefaultLogger` only dates back to 65c2675b (2017-05-11, #2), so it wasn't around yet when 7fc4de0e landed.  Personally, I'd rather leave users to clobber `DefaultLogger` explicitly if they want to.