### PR TITLE
capture: Add a log-capturing implementation

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -1,0 +1,40 @@
+// Package capture implements the Logger interface by capturing logged
+// lines.  This is useful for log inspection during unit-testing,
+// if you want to assert that a particular line has, or has not, been
+// logged.
+package capture
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Logger implements the log.Logger interface by capturing logged
+// lines.
+type Logger struct {
+	mutex *sync.Mutex
+
+	// Entries holds logged entries in submission order.
+	Entries []string
+}
+
+func (logger *Logger) Log(v ...interface{}) {
+	logger.log(fmt.Sprint(v...))
+}
+
+func (logger *Logger) Logf(format string, v ...interface{}) {
+	logger.log(fmt.Sprintf(format, v...))
+}
+
+func (logger *Logger) log(entry string) {
+	logger.mutex.Lock()
+	defer logger.mutex.Unlock()
+	logger.Entries = append(logger.Entries, entry)
+}
+
+func New() *Logger {
+	return &Logger{
+		mutex:   &sync.Mutex{},
+		Entries: []string{},
+	}
+}

--- a/capture/capture_test.go
+++ b/capture/capture_test.go
@@ -1,0 +1,35 @@
+package capture
+
+import (
+	"testing"
+
+	"github.com/go-log/log"
+)
+
+func testLog(l log.Logger) {
+	l.Log("test")
+}
+
+func testLogf(l log.Logger) {
+	l.Logf("%s", "test")
+}
+
+func TestFMTLogger(t *testing.T) {
+	logger := New()
+	testLog(logger)
+	testLogf(logger)
+	expectedEntries := []string{"test", "test"}
+	for i, expectedEntry := range expectedEntries {
+		if i >= len(logger.Entries) {
+			t.Errorf("missing expected entry %d: %q", i, expectedEntry)
+			continue
+		}
+		actualEntry := logger.Entries[i]
+		if actualEntry != expectedEntry {
+			t.Errorf("unexpected entry %d: %q (expected %q)", i, actualEntry, expectedEntry)
+		}
+	}
+	if len(logger.Entries) > len(expectedEntries) {
+		t.Errorf("additional unexpected entries: %v", logger.Entries[len(expectedEntries):])
+	}
+}


### PR DESCRIPTION
This is useful for log inspection during unit-testing, if you want to assert that a particular line has, or has not, been logged.