### PR TITLE
print: Add a generic wrapper for objects which supply Print and Printf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,43 +21,20 @@ type Logger interface {
 
 ## Example
 
-Here's a logger that uses logrus and logs with predefined fields.
+Pre-configure a logger using [`WithFields`][logrus.WithFields] and pass it as an option to a library:
 
 ```go
 import (
-	"github.com/go-log/log"
+	"github.com/go-log/log/print"
+	"github.com/lib/foo"
 	"github.com/sirupsen/logrus"
 )
 
-type logrusLogger struct {
-	*logrus.Entry
-}
-
-func (l *logrusLogger) Log(v ...interface{}) {
-	l.Entry.Print(v...)
-}
-
-func (l *logrusLogger) Logf(format string, v ...interface{}) {
-	l.Entry.Printf(format, v...)
-}
-
-func WithFields(f logrus.Fields) log.Logger {
-	return &logrusLogger{logrus.WithFields(f)}	
-}
-```
-
-The `WithFields` func returns a struct that satisfies the Logger interface.
-
-Pre-configure a logger using WithFields and pass it as an option to a library.
-
-```go
-import "github.com/lib/foo"
-
-l := mylogger.WithFields(logrus.Fields{
+logger := print.New(logrus.WithFields(logrus.Fields{
 	"library": "github.com/lib/foo",
-})
+}))
 
-f := foo.New(
-	foo.WithLogger(l),
-)
+f := foo.New(logger)
 ```
+
+[logrus.WithFields]: https://godoc.org/github.com/sirupsen/logrus#WithFields

--- a/logrus/logrus.go
+++ b/logrus/logrus.go
@@ -1,33 +1,29 @@
+// Package logrus allows the creation of Loggers based on
+// logrus.StandardLogger().
+//
+// Deprecated: Use github.com/go-log/log/print instead.
 package logrus
 
 import (
+	"github.com/go-log/log"
+	"github.com/go-log/log/print"
 	"github.com/sirupsen/logrus"
 )
 
-type logrusLogger struct {
-	*logrus.Entry
+// WithFields creates a new logger based on logrus.WithFields().
+//
+// Deprecated: Replace with:
+//
+//   print.New(logrus.WithFields(f))
+func WithFields(f logrus.Fields) log.Logger {
+	return print.New(logrus.WithFields(f))
 }
 
-func (l *logrusLogger) Log(v ...interface{}) {
-	if l.Entry != nil {
-		l.Entry.Print(v...)
-	} else {
-		logrus.Print(v...)
-	}
-}
-
-func (l *logrusLogger) Logf(format string, v ...interface{}) {
-	if l.Entry != nil {
-		l.Entry.Printf(format, v...)
-	} else {
-		logrus.Printf(format, v...)
-	}
-}
-
-func WithFields(f logrus.Fields) *logrusLogger {
-	return &logrusLogger{logrus.WithFields(f)}
-}
-
-func New() *logrusLogger {
-	return &logrusLogger{}
+// WithFields creates a new logger based on logrus.StandardLogger().
+//
+// Deprecated: Replace with:
+//
+//   print.New(logrus.StandardLogger())
+func New() log.Logger {
+	return print.New(logrus.StandardLogger())
 }

--- a/print/print.go
+++ b/print/print.go
@@ -1,0 +1,28 @@
+// Package print allows users to create a Logger interface from any
+// object that supports Print and Printf.
+package print
+
+// Printer is an interface for Print and Printf.
+type Printer interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
+type logger struct{
+	printer Printer
+}
+
+func (logger *logger) Log(v ...interface{}) {
+	logger.printer.Print(v...)
+}
+
+func (logger *logger) Logf(format string, v ...interface{}) {
+	logger.printer.Printf(format, v...)
+}
+
+// New creates a new logger wrapping printer.
+func New(printer Printer) *logger {
+	return &logger{
+		printer: printer,
+	}
+}

--- a/print/print_test.go
+++ b/print/print_test.go
@@ -1,0 +1,32 @@
+package print
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-log/log"
+)
+
+type printer struct {}
+
+func (*printer) Print(v ...interface{}) {
+	fmt.Print(v...)
+}
+
+func (*printer) Printf(format string, v ...interface{}) {
+	fmt.Printf(format, v...)
+}
+
+func testLog(l log.Logger) {
+	l.Log("test\n")
+}
+
+func testLogf(l log.Logger) {
+	l.Logf("%s", "test\n")
+}
+
+func TestNew(t *testing.T) {
+	l := New(&printer{})
+	testLog(l)
+	testLogf(l)
+}


### PR DESCRIPTION
I want this so I can convert a `*logrus.Logger` (that is not [`logrus.StandardLogger()`][1]) to a `log.Logger` interface.

You can almost do the same thing with the `fmt` implementation.  Unfortunately, imported packages do not seem to be first-class objects in Go, with:

```go
import (
  "fmt"

  "github.com/go-log/log/print"
)

// ...

print.New(fmt)
```

raising:

    use of package fmt without selector

We could work around that if fmt supplied an analog to `logrus.StandardLogger()`, but it doesn't as of Go 1.10.3.

[1]: https://godoc.org/github.com/sirupsen/logrus#pkg-constants