### PR TITLE
info: Add a generic wrapper for objects which supply Info and Infof

### DIFF
--- a/info/info.go
+++ b/info/info.go
@@ -1,0 +1,28 @@
+// Package info allows users to create a Logger interface from any
+// object that supports Info and Infof.
+package info
+
+// Info is an interface for Info and Infof.
+type Info interface {
+	Info(v ...interface{})
+	Infof(format string, v ...interface{})
+}
+
+type logger struct{
+	info Info
+}
+
+func (logger *logger) Log(v ...interface{}) {
+	logger.info.Info(v...)
+}
+
+func (logger *logger) Logf(format string, v ...interface{}) {
+	logger.info.Infof(format, v...)
+}
+
+// New creates a new logger wrapping info.
+func New(info Info) *logger {
+	return &logger{
+		info: info,
+	}
+}

--- a/info/info_test.go
+++ b/info/info_test.go
@@ -1,0 +1,32 @@
+package info
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-log/log"
+)
+
+type info struct {}
+
+func (*info) Info(v ...interface{}) {
+	fmt.Print(v...)
+}
+
+func (*info) Infof(format string, v ...interface{}) {
+	fmt.Printf(format, v...)
+}
+
+func testLog(l log.Logger) {
+	l.Log("test\n")
+}
+
+func testLogf(l log.Logger) {
+	l.Logf("%s", "test\n")
+}
+
+func TestNew(t *testing.T) {
+	l := New(&info{})
+	testLog(l)
+	testLogf(l)
+}


### PR DESCRIPTION
I want this so I can use a `log.Logger` library in a [glog][1] application, with an initialization like:

```go
import (
  "github.com/go-log/log/info"
  "github.com/golang/glog"
  "github.com/lib/foo"
)

logger := info.New(glog.V(2))
f := foo.New(logger)
```

The approach I'm taking is very similar to #6, but with `Info` and `Infof` instead of #6's `Print` and `Printf`.

[1]: https://godoc.org/github.com/golang/glog