### PR TITLE
fmt: Add trailing newlines

### DIFF
--- a/appengine/appengine_test.go
+++ b/appengine/appengine_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func testLog(l log.Logger) {
-	l.Log("test\n")
+	l.Log("test")
 }
 
 func testLogf(l log.Logger) {
-	l.Logf("%s", "test\n")
+	l.Logf("%s", "test")
 }
 
 func TestLogLogger(t *testing.T) {

--- a/fmt/fmt.go
+++ b/fmt/fmt.go
@@ -2,18 +2,37 @@ package fmt
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
 )
 
-type fmtLogger struct{}
+type fmtLogger struct {
+	writer io.Writer
+}
 
 func (t *fmtLogger) Log(v ...interface{}) {
-	fmt.Print(v...)
+	t.output(fmt.Sprint(v...))
 }
 
 func (t *fmtLogger) Logf(format string, v ...interface{}) {
-	fmt.Printf(format, v...)
+	t.output(fmt.Sprintf(format, v...))
 }
 
+func (logger *fmtLogger) output(line string) (n int, err error) {
+	if !strings.HasSuffix(line, "\n") {
+		line += "\n"
+	}
+	return logger.writer.Write([]byte(line))
+}
+
+// New creates a new fmt logger which writes to stdout.
 func New() *fmtLogger {
-	return &fmtLogger{}
+	return &fmtLogger{writer: os.Stdout}
+}
+
+// NewFromWriter creates a new fmt logger which writes to the given
+// writer.
+func NewFromWriter(writer: io.Writer) *fmtLogger {
+	return &fmtLogger{writer: writer}
 }

--- a/fmt/fmt_test.go
+++ b/fmt/fmt_test.go
@@ -1,21 +1,22 @@
 package fmt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-log/log"
 )
 
-func testLog(l log.Logger) {
-	l.Log("test\n")
-}
-
-func testLogf(l log.Logger) {
-	l.Logf("%s", "test\n")
-}
-
 func TestFMTLogger(t *testing.T) {
-	l := new(fmtLogger)
-	testLog(l)
-	testLogf(l)
+	builder := &strings.Builder{}
+	var logger log.Logger
+	logger = &fmtLogger{writer: builder}
+	logger.Log("a")
+	logger.Log("b\n")
+	logger.Logf("%s", "c")
+	logger.Logf("%s\n", "d")
+	expected := "a\nb\nc\nd\n"
+	if builder.String() != expected {
+		t.Fatalf("got %q, expected %q", builder.String(), expected)
+	}
 }

--- a/info/info_test.go
+++ b/info/info_test.go
@@ -10,19 +10,19 @@ import (
 type info struct {}
 
 func (*info) Info(v ...interface{}) {
-	fmt.Print(v...)
+	fmt.Println(v...)
 }
 
 func (*info) Infof(format string, v ...interface{}) {
-	fmt.Printf(format, v...)
+	fmt.Printf(format+"\n", v...)
 }
 
 func testLog(l log.Logger) {
-	l.Log("test\n")
+	l.Log("test")
 }
 
 func testLogf(l log.Logger) {
-	l.Logf("%s", "test\n")
+	l.Logf("%s", "test")
 }
 
 func TestNew(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func testLog(l log.Logger) {
-	l.Log("test\n")
+	l.Log("test")
 }
 
 func testLogf(l log.Logger) {
-	l.Logf("%s", "test\n")
+	l.Logf("%s", "test")
 }
 
 func TestLogLogger(t *testing.T) {

--- a/log_test.go
+++ b/log_test.go
@@ -15,11 +15,11 @@ func (t *testLogger) Logf(format string, v ...interface{}) {
 }
 
 func testLog(l Logger) {
-	l.Log("test\n")
+	l.Log("test")
 }
 
 func testLogf(l Logger) {
-	l.Logf("%s\n", "test")
+	l.Logf("%s", "test")
 }
 
 func TestLogger(t *testing.T) {

--- a/logrus/logrus_test.go
+++ b/logrus/logrus_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func testLog(l log.Logger) {
-	l.Log("test\n")
+	l.Log("test")
 }
 
 func testLogf(l log.Logger) {
-	l.Logf("%s", "test\n")
+	l.Logf("%s", "test")
 }
 
 func TestLogLogger(t *testing.T) {

--- a/print/print_test.go
+++ b/print/print_test.go
@@ -7,22 +7,22 @@ import (
 	"github.com/go-log/log"
 )
 
-type printer struct {}
+type printer struct{}
 
 func (*printer) Print(v ...interface{}) {
-	fmt.Print(v...)
+	fmt.Println(v...)
 }
 
 func (*printer) Printf(format string, v ...interface{}) {
-	fmt.Printf(format, v...)
+	fmt.Printf(format+"\n", v...)
 }
 
 func testLog(l log.Logger) {
-	l.Log("test\n")
+	l.Log("test")
 }
 
 func testLogf(l log.Logger) {
-	l.Logf("%s", "test\n")
+	l.Logf("%s", "test")
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
Log users generally don't include explict trailing newlines in their log messages, but expect them to be appended by their logger when the output format expects them (e.g. information logged to standard streams).  For example, the stdlib log package supplies [`Print`][1], [`Printf`][2], and [`Println`][3], but all three are backed by [`Output`][4].  And [`Output` appends a trailing newline][4] if the supplied string does not already include one.  In fact, explicit trailing newlines in `Logger` calls might be troublesome for loggers that do not want trailing newlines (e.g. if you're logging to JSON).  This commit updates our fmt implementation to append trailing newlines so callers don't have to set them explicitly.

[1]: https://golang.org/pkg/log/#Print
[2]: https://golang.org/pkg/log/#Printf
[3]: https://golang.org/pkg/log/#Println
[4]: https://golang.org/pkg/log/#Output