### PR TITLE
nest: Add a sub-package for creating sub-loggers

### DIFF
--- a/log.go
+++ b/log.go
@@ -3,7 +3,14 @@ package log
 
 // Logger is a generic logging interface
 type Logger interface {
+
+	// Log inserts a log entry.  Arguments may be handled in the manner
+	// of fmt.Print, but the underlying logger may also decide to handle
+	// them differently.
 	Log(v ...interface{})
+
+	// Logf insets a log entry.  Arguments are handled in the manner of
+	// fmt.Printf.
 	Logf(format string, v ...interface{})
 }
 

--- a/nest/nest.go
+++ b/nest/nest.go
@@ -1,0 +1,36 @@
+// Package nest allows users to use a Logger interface to
+// create another Logger interface.
+package nest
+
+import (
+	"fmt"
+
+	"github.com/go-log/log"
+)
+
+type logger struct {
+	logger log.Logger
+	values []interface{}
+}
+
+func (logger *logger) Log(v ...interface{}) {
+	logger.logger.Log(append(logger.values, v...)...)
+}
+
+func (logger *logger) Logf(format string, v ...interface{}) {
+	logger.logger.Log(append(logger.values, fmt.Sprintf(format, v...))...)
+}
+
+func New(log log.Logger, v ...interface{}) *logger {
+	return &logger{
+		logger: log,
+		values: v,
+	}
+}
+
+func Newf(log log.Logger, format string, v ...interface{}) *logger {
+	return &logger{
+		logger: log,
+		values: []interface{}{fmt.Sprintf(format, v...)},
+	}
+}

--- a/nest/nest_test.go
+++ b/nest/nest_test.go
@@ -1,0 +1,49 @@
+package nest
+
+import (
+	"testing"
+
+	"github.com/go-log/log/capture"
+)
+
+func TestNew(t *testing.T) {
+	base := capture.New()
+	logger := New(base, " ", map[string]interface{}{"key": "value", "count": 1}, " ")
+	logger.Log("Log()", "arg")
+	logger.Logf("Logf(%s)", "arg")
+	expectedEntries := []string{" map[key:value count:1] Log()arg", " map[key:value count:1] Logf(arg)"}
+	for i, expectedEntry := range expectedEntries {
+		if i >= len(base.Entries) {
+			t.Errorf("missing expected entry %d: %q", i, expectedEntry)
+			continue
+		}
+		actualEntry := base.Entries[i]
+		if actualEntry != expectedEntry {
+			t.Errorf("unexpected entry %d: %q (expected %q)", i, actualEntry, expectedEntry)
+		}
+	}
+	if len(base.Entries) > len(expectedEntries) {
+		t.Errorf("additional unexpected entries: %v", base.Entries[len(expectedEntries):])
+	}
+}
+
+func TestNewf(t *testing.T) {
+	base := capture.New()
+	logger := Newf(base, "wrap(%s,%d)", "a", 1)
+	logger.Log("Log()", "arg")
+	logger.Logf("Logf(%s)", "arg")
+	expectedEntries := []string{"wrap(a,1)Log()arg", "wrap(a,1)Logf(arg)"}
+	for i, expectedEntry := range expectedEntries {
+		if i >= len(base.Entries) {
+			t.Errorf("missing expected entry %d: %q", i, expectedEntry)
+			continue
+		}
+		actualEntry := base.Entries[i]
+		if actualEntry != expectedEntry {
+			t.Errorf("unexpected entry %d: %q (expected %q)", i, actualEntry, expectedEntry)
+		}
+	}
+	if len(base.Entries) > len(expectedEntries) {
+		t.Errorf("additional unexpected entries: %v", base.Entries[len(expectedEntries):])
+	}
+}


### PR DESCRIPTION
Some libraries may want to add structure to child logs.  For example, say your library takes a `Logger` and it turns around and passes that `Logger` down into some child calls that are processing a request for `https://example.com/some/resource`.  Those child calls don't care about the original URI, but you want that URI to show up in anything logged by the children for context.  With this package, you can set that up with:

```go
func middleman(logger log.Logger) error {
  uri := "https://example.com/some/resource"
  resp, err := http.Get(uri)
  if err != nil {
    return err
  }
  return child(resp, nest.New(" ", uri, " "))
}
```

The buffering spaces are a bit awkward, but several loggers follow `fmt.Sprint`, which [only adds spaces between operands when neither is a string][1].  For example:

```console
$ cat test.go
package main

import (
  "flag"
  "log"

  "github.com/golang/glog"
  "github.com/sirupsen/logrus"
)

func main() {
  flag.Parse()
  log.Print("a", "b")
  glog.Info("c", "d")
  logrus.Info("e", "f")
  logrus.WithFields(map[string]interface{}{"key": "value", "count": 1}).Info("g", "h")
}
$ go run test.go -logtostderr
2018/11/10 21:16:54 ab
I1110 21:16:54.589271   13508 test.go:14] cd
INFO[0000] ef
INFO[0000] gh                                            count=1 key=value
```

So it's probably a good idea to add the separating spaces.  Structured base loggers that preserve separate arguments should probably check for and discard any arguments matching the single-space string.

As the unit tests show, `New(...)` can be used in the style of `logrus.WithFields` to add structured information as well (although as discussed above, the final output depends on how the base logger handles `Log(...)` values).  You could certainly write a logrus wrapper whose `Log` implementation that used `WithFields` on any arguments that successfully cast to `logrus.Fields`.

[1]: https://golang.org/pkg/fmt/#Sprint
[2]: https://godoc.org/github.com/sirupsen/logrus#WithFields